### PR TITLE
Add String prop to MapPreview

### DIFF
--- a/src/components/atoms/MapPreview.vue
+++ b/src/components/atoms/MapPreview.vue
@@ -1,15 +1,16 @@
 <template>
-  <div class="map">
-    <l-map :zoom="zoom" :center="center"
+  <div class="map" v-if="coordinates">
+    <l-map :zoom="zoom" :center="coordinates"
       :options="{ zoomControl: false, scrollWheelZoom: false, dragging: false, doubleClickZoom: false }" ref="mapRef">
       <l-tile-layer :url="url" :attribution="attribution"></l-tile-layer>
-      <l-marker :lat-lng="center"></l-marker>
+      <l-marker :lat-lng="coordinates"></l-marker>
     </l-map>
   </div>
 </template>
 
 <script>
-import "leaflet/dist/leaflet.css"
+import "leaflet/dist/leaflet.css";
+import axios from "axios";
 import { LMap, LMarker, LTileLayer } from "@vue-leaflet/vue-leaflet";
 
 export default {
@@ -26,15 +27,41 @@ export default {
     },
     center: {
       type: Array,
-      required: true,
+      required: false,
+    },
+    address: {
+      type: String,
+      required: false,
     },
   },
   data() {
     return {
+      coordinates: '',
       url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       attribution:
         '&copy; <a target="_blank" href="https://osm.org/copyright">OpenStreetMap</a> contributors',
     };
+  },
+  methods: {
+    async updateCenterByLocation(newAddress) {
+      const response = await axios.get(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(newAddress)}`);
+      if (response.data[0]) {
+        this.coordinates = [response.data[0].lat, response.data[0].lon];
+      }
+    },
+  },
+  watch: {
+    async address(newAddress) {
+      await this.updateCenterByLocation(newAddress);
+    },
+  },
+  async mounted() {
+    if (this.address) {
+      await this.updateCenterByLocation(this.address);
+    }
+    if (this.center) {
+      this.coordinates = this.center;
+    }
   },
 };
 </script>


### PR DESCRIPTION
Idea of this change is to allow the map to take location in form of a string sent to OSM (Like, "Polska, Łódź, Wólczańska 210"). This could be useful while creating offers, as during the inputting of location the map would center on the given location automatically. 