### PR TITLE
Fix no gap on OfferPreview in Main

### DIFF
--- a/src/components/organisms/OfferPreview.vue
+++ b/src/components/organisms/OfferPreview.vue
@@ -175,6 +175,8 @@ export default {
 
 .offer-preview-action {
   padding: 2%;
+  margin-right: max(2%, 15px);
+  width: 30%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
rn when on Main, the stars would display themselves way too close to border if the surname was short